### PR TITLE
fixed external links to jekyll documentation

### DIFF
--- a/docs/blogging/index.html
+++ b/docs/blogging/index.html
@@ -120,10 +120,10 @@ The default file extension for new posts is <code>markdown</code> but you can co
 </div><div class='line'><span class="c"># Creates source/_posts/2011-07-03-zombie-ninjas-attack-a-survivors-retrospective.markdown</span>
 </div></pre></td></tr></table></div></figure>
 
-<p>The filename will determine your url. With the default <a href="https://github.com/mojombo/jekyll/wiki/Permalinks">permalink settings</a> the url would be something like
+<p>The filename will determine your url. With the default <a href="http://jekyllrb.com/docs/permalinks/">permalink settings</a> the url would be something like
 <code>http://site.com/blog/2011/07/03/zombie-ninjas-attack-a-survivors-retrospective/index.html</code>.</p>
 
-<p>Open a post in a text editor and you&#39;ll see a block of <a href="https://github.com/mojombo/jekyll/wiki/yaml-front-matter">yaml front matter</a>
+<p>Open a post in a text editor and you&#39;ll see a block of <a href="http://jekyllrb.com/docs/frontmatter/">yaml front matter</a>
 which tells Jekyll how to processes posts and pages.</p>
 
 <figure class='code'><div class='highlight'><table><td class='line-numbers' aria-hidden='true'><pre><div data-line='1' class='line-number'></div><div data-line='2' class='line-number'></div><div data-line='3' class='line-number'></div><div data-line='4' class='line-number'></div><div data-line='5' class='line-number'></div><div data-line='6' class='line-number'></div><div data-line='7' class='line-number'></div><div data-line='8' class='line-number'></div></pre></td><td class='main  yaml'><pre><div class='line'><span class="nn">---</span>


### PR DESCRIPTION
Links to permalinks and frontmatter no longer exist on the jekyll wiki but are now on jekyllrb.com.
